### PR TITLE
refactor(core): optimize protection registry and reconcile logic

### DIFF
--- a/composeshield/build.gradle.kts
+++ b/composeshield/build.gradle.kts
@@ -231,8 +231,13 @@ val generateValidationReport by tasks.registering {
                 // Match <testcase ...> blocks regardless of attribute order
                 Regex("""<testcase\b([^>]+)""").findAll(content).forEach { m ->
                     val attrs = m.groupValues[1]
-                    val fullClass = Regex("""classname=["']([^"']+)["']""").find(attrs)?.groupValues?.get(1) ?: ""
-                    val method = Regex("""name=["']([^"']+)["']""").find(attrs)?.groupValues?.get(1) ?: ""
+                    // The \b anchors are load-bearing: without one, `name=` also matches inside
+                    // `classname=`, every method resolves to the class FQN, and no testcase ever
+                    // matches the id-map — every test would report "blocked".
+                    val fullClass =
+                        Regex("""\bclassname=["']([^"']+)["']""").find(attrs)?.groupValues?.get(1) ?: ""
+                    val method =
+                        Regex("""\bname=["']([^"']+)["']""").find(attrs)?.groupValues?.get(1) ?: ""
                     if (fullClass.isBlank() || method.isBlank()) return@forEach
 
                     // Match against test-id-map

--- a/composeshield/src/androidHostTest/kotlin/io/github/composeshield/SecureContentTest.kt
+++ b/composeshield/src/androidHostTest/kotlin/io/github/composeshield/SecureContentTest.kt
@@ -125,27 +125,33 @@ class SecureContentTest {
     @Test
     fun `a freshly allocated equal capability set does not restart the protection effect`() =
         runComposeUiTest {
-            // The hazard: a consumer writing `capabilities = setOf(...)` inline allocates a new,
-            // equal set on every recomposition. Keying the effect on that raw parameter would
-            // release/re-apply each time — on Android a FLAG_SECURE toggle, i.e. surface teardown.
+            // Two traps make this test easy to write vacuously. First, mutableStateOf compares
+            // structurally, so assigning an equal set produces no recomposition at all. Second,
+            // Compose effect keys compare with equals(), so an equal set would not restart the
+            // effect even if the body re-ran. A separate tick state, read inside composition,
+            // forces genuine recompositions while the capability argument stays fresh-but-equal;
+            // the composition counter proves those recompositions really happened.
             val capabilities = mutableStateOf(setOf(Capability.ScreenshotPrevention))
+            val tick = mutableStateOf(0)
+            var compositions = 0
 
             setContent {
-                // toSet() makes the instability explicit: a fresh instance every recomposition.
-                SecureContent(capabilities = capabilities.value.toSet()) { }
+                tick.value // subscribe: every bump must re-run this body
+                SecureContent(capabilities = capabilities.value.toSet()) { compositions++ }
             }
             waitForIdle()
             val settled = shieldCore.registry.snapshots.value
 
-            // Every acquire/release produces a new RegistryState instance, so reference identity of
-            // the published snapshot is an effect-restart detector: same instance ⇒ no restart.
-            capabilities.value = setOf(Capability.ScreenshotPrevention)
+            tick.value = 1
             waitForIdle()
-
+            assertTrue(
+                compositions >= 2,
+                "the tick must force a real recomposition, or the identity assertion below is vacuous",
+            )
             assertSame(
                 settled,
                 shieldCore.registry.snapshots.value,
-                "a fresh-but-equal set must not release/re-acquire protection",
+                "a fresh-but-equal capability set across recompositions must not release/re-apply protection",
             )
 
             capabilities.value = setOf(Capability.ScreenshotPrevention, Capability.RecordingPrevention)

--- a/composeshield/src/androidHostTest/kotlin/io/github/composeshield/SecureContentTest.kt
+++ b/composeshield/src/androidHostTest/kotlin/io/github/composeshield/SecureContentTest.kt
@@ -5,12 +5,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
+import io.github.composeshield.internal.shieldCore
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -117,6 +120,43 @@ class SecureContentTest {
                 ComposeShield.isProtectionActive(),
                 "the DisposableEffect restarts on a capability change; protection must survive the swap",
             )
+        }
+
+    @Test
+    fun `a freshly allocated equal capability set does not restart the protection effect`() =
+        runComposeUiTest {
+            // The hazard: a consumer writing `capabilities = setOf(...)` inline allocates a new,
+            // equal set on every recomposition. Keying the effect on that raw parameter would
+            // release/re-apply each time — on Android a FLAG_SECURE toggle, i.e. surface teardown.
+            val capabilities = mutableStateOf(setOf(Capability.ScreenshotPrevention))
+
+            setContent {
+                // toSet() makes the instability explicit: a fresh instance every recomposition.
+                SecureContent(capabilities = capabilities.value.toSet()) { }
+            }
+            waitForIdle()
+            val settled = shieldCore.registry.snapshots.value
+
+            // Every acquire/release produces a new RegistryState instance, so reference identity of
+            // the published snapshot is an effect-restart detector: same instance ⇒ no restart.
+            capabilities.value = setOf(Capability.ScreenshotPrevention)
+            waitForIdle()
+
+            assertSame(
+                settled,
+                shieldCore.registry.snapshots.value,
+                "a fresh-but-equal set must not release/re-acquire protection",
+            )
+
+            capabilities.value = setOf(Capability.ScreenshotPrevention, Capability.RecordingPrevention)
+            waitForIdle()
+
+            assertNotSame(
+                settled,
+                shieldCore.registry.snapshots.value,
+                "a genuinely different set must still re-acquire",
+            )
+            assertTrue(ComposeShield.isProtectionActive())
         }
 
     @Test

--- a/composeshield/src/androidMain/kotlin/io/github/composeshield/internal/AppSwitcher.android.kt
+++ b/composeshield/src/androidMain/kotlin/io/github/composeshield/internal/AppSwitcher.android.kt
@@ -3,6 +3,9 @@ package io.github.composeshield.internal
 import android.os.Build
 import io.github.composeshield.SupportLevel
 
+/** The API level that introduced `setRecentsScreenshotEnabled`; the capability's single floor. */
+private const val RECENTS_SCREENSHOT_API = Build.VERSION_CODES.TIRAMISU
+
 /**
  * Standalone recents protection via `Activity.setRecentsScreenshotEnabled(false)` (API 33+).
  *
@@ -20,13 +23,13 @@ import io.github.composeshield.SupportLevel
  * reflection, which the zero-reflection guarantee forbids outright.
  */
 internal class AppSwitcher {
-    fun support(): SupportLevel = supportedFromApi(Build.VERSION_CODES.TIRAMISU)
+    fun support(): SupportLevel = supportedFromApi(RECENTS_SCREENSHOT_API)
 
     fun apply(
         window: WindowKey,
         enabled: Boolean,
     ) {
-        if (sdkInt < Build.VERSION_CODES.TIRAMISU) return
+        if (sdkInt < RECENTS_SCREENSHOT_API) return
         val activity = activityFor(window) ?: anyRegisteredActivity() ?: return
 
         onMainThread(ifDeferred = Unit) {

--- a/composeshield/src/androidMain/kotlin/io/github/composeshield/internal/ScreenshotEvents.android.kt
+++ b/composeshield/src/androidMain/kotlin/io/github/composeshield/internal/ScreenshotEvents.android.kt
@@ -8,6 +8,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.emptyFlow
 
+/** The API level that introduced `Activity.ScreenCaptureCallback`; the capability's single floor. */
+private const val SCREEN_CAPTURE_CALLBACKS_API = Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
 /**
  * Emits once per screenshot, via `Activity.registerScreenCaptureCallback` (API 34+).
  *
@@ -21,10 +24,10 @@ import kotlinx.coroutines.flow.emptyFlow
  * registry state this class deliberately knows nothing about.
  */
 internal class ScreenshotEvents {
-    fun support(): SupportLevel = supportedFromApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    fun support(): SupportLevel = supportedFromApi(SCREEN_CAPTURE_CALLBACKS_API)
 
     fun events(): Flow<Unit> {
-        if (sdkInt < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return emptyFlow()
+        if (sdkInt < SCREEN_CAPTURE_CALLBACKS_API) return emptyFlow()
 
         return callbackFlow {
             val activity = anyRegisteredActivity()

--- a/composeshield/src/androidMain/kotlin/io/github/composeshield/internal/Serialized.android.kt
+++ b/composeshield/src/androidMain/kotlin/io/github/composeshield/internal/Serialized.android.kt
@@ -1,0 +1,6 @@
+package io.github.composeshield.internal
+
+internal actual inline fun <R> serialized(
+    lock: Any,
+    block: () -> R,
+): R = kotlin.synchronized(lock, block)

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/ComposeShield.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/ComposeShield.kt
@@ -81,9 +81,12 @@ public object ComposeShield {
      * Starts at [CaptureState.Unknown] and is **never seeded to [CaptureState.Inactive]** — read
      * that type's documentation before branching on it, because `Inactive` means "no evidence of
      * capture", not "not being captured".
+     *
+     * Observation begins when the library first initializes, not on this property's first read — a
+     * property read must not start work.
      */
     public val captureState: StateFlow<CaptureState>
-        get() = shieldCore.captureStates.also { it.start() }.state
+        get() = shieldCore.captureStates.state
 
     /**
      * Emits once per screenshot, after the fact.
@@ -102,7 +105,9 @@ public object ComposeShield {
      * Emits when a prevention mechanism fails to install or stops working.
      *
      * The application-wide counterpart to `SecureContent`'s `onProtectionFailure`, for consumers
-     * using the imperative path.
+     * using the imperative path. The most recent failure is replayed to a collector that attaches
+     * after it was emitted — a security-relevant signal must not be lost because nobody was
+     * listening yet.
      */
     public val protectionFailures: Flow<Capability> get() = shieldCore.protectionFailures
 

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/SecureContent.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/SecureContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.composeshield.internal.rememberWindowKey
 import io.github.composeshield.internal.shieldCore
@@ -30,10 +31,14 @@ import io.github.composeshield.internal.shieldCore
  * change and background/restore without re-invocation, and renders [content] identically to an
  * unwrapped call.
  *
- * @param capabilities which preventions to request. The default is a compile-time constant, not a
- *   fresh set per recomposition.
+ * @param capabilities which preventions to request. Changes are honoured — a genuinely different set
+ *   re-acquires — but a freshly-allocated yet *equal* set per recomposition neither releases nor
+ *   re-applies: the boundary stabilizes the set internally, because re-applying on Android toggles
+ *   `FLAG_SECURE` and tears down the window's surface, which the user sees as a black frame. The
+ *   default is a compile-time constant, not a fresh set per recomposition.
  * @param onProtectionFailure invoked when a requested mechanism fails to install or stops working
- *   mid-session.
+ *   mid-session. Invoked from a composition coroutine and guarded: a throwing callback cannot crash
+ *   the host application, though it will not be re-invoked for that failure either.
  * @param content the protected content. Rendered unchanged.
  */
 @Composable
@@ -44,10 +49,19 @@ public fun SecureContent(
 ) {
     val window = rememberWindowKey()
 
-    val currentOnFailure by rememberUpdatedState(onProtectionFailure)
+    // remember compares its key by equality, not identity, so a consumer allocating a fresh-but-equal
+    // set every recomposition recomputes nothing here and the effect below does not restart. Keying
+    // the effect on the raw parameter instead would release/re-apply protection on each of those
+    // recompositions — the surface-tearing toggle documented above.
+    val stableCapabilities = remember(capabilities) { capabilities.toSet() }
 
-    DisposableEffect(window, capabilities) {
-        val request = shieldCore.registry.acquire(window, capabilities)
+    val currentOnFailure by rememberUpdatedState(onProtectionFailure)
+    // The failure filter must read the CURRENT set, not the one captured when the collector started:
+    // a capability added mid-session should report its failures, a removed one should stop reporting.
+    val currentCapabilities by rememberUpdatedState(capabilities)
+
+    DisposableEffect(window, stableCapabilities) {
+        val request = shieldCore.registry.acquire(window, stableCapabilities)
         shieldCore.registry.bindWindow(window)
         onDispose { shieldCore.registry.release(request) }
     }
@@ -55,7 +69,13 @@ public fun SecureContent(
     if (onProtectionFailure != null) {
         LaunchedEffect(Unit) {
             shieldCore.protectionFailures.collect { failed ->
-                if (failed in capabilities) currentOnFailure?.invoke(failed)
+                if (failed in currentCapabilities) {
+                    // A consumer callback runs inside this composition coroutine; letting it throw
+                    // would kill the host app — precisely the failure mode this library exists to
+                    // prevent. The swallow is deliberate: the durable truth (supportLevel and the
+                    // registry's failedMechanisms) is unaffected, only this best-effort channel is.
+                    runCatching { currentOnFailure?.invoke(failed) }
+                }
             }
         }
     }

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/SecureContent.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/SecureContent.kt
@@ -52,9 +52,9 @@ public fun SecureContent(
     // remember compares its key by equality, not identity, so a consumer allocating a fresh-but-equal
     // set every recomposition recomputes nothing here and the effect below does not restart. Keying
     // the effect on the raw parameter instead would release/re-apply protection on each of those
-    // recompositions — the surface-tearing toggle documented above.
-    val capabilitySnapshot = capabilities.toSet()
-    val stableCapabilities = remember(capabilitySnapshot) { capabilitySnapshot }
+    // recompositions — the surface-tearing toggle documented above. The copy runs inside remember's
+    // calculation, so equal sets cost no allocation at all on the steady-state path.
+    val stableCapabilities = remember(capabilities) { capabilities.toSet() }
 
     val currentOnFailure by rememberUpdatedState(onProtectionFailure)
     // The failure filter must read the CURRENT set, not the one captured when the collector started:
@@ -70,6 +70,13 @@ public fun SecureContent(
     if (onProtectionFailure != null) {
         LaunchedEffect(Unit) {
             shieldCore.protectionFailures.collect { failed ->
+                // The flow replays its most recent failure to late collectors; that replay can
+                // outlive the failure it describes (the capability was released and has since
+                // installed cleanly — pruned from failedMechanisms). A capability not currently
+                // recorded as failed is stale news, so it is dropped here: fresh failures are
+                // always still in the set when emitted, so nothing genuine is lost.
+                if (failed !in shieldCore.registry.current.failedMechanisms) return@collect
+
                 if (failed in currentCapabilities) {
                     // A consumer callback runs inside this composition coroutine; letting it throw
                     // would kill the host app — precisely the failure mode this library exists to

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/SecureContent.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/SecureContent.kt
@@ -53,7 +53,8 @@ public fun SecureContent(
     // set every recomposition recomputes nothing here and the effect below does not restart. Keying
     // the effect on the raw parameter instead would release/re-apply protection on each of those
     // recompositions — the surface-tearing toggle documented above.
-    val stableCapabilities = remember(capabilities) { capabilities.toSet() }
+    val capabilitySnapshot = capabilities.toSet()
+    val stableCapabilities = remember(capabilitySnapshot) { capabilitySnapshot }
 
     val currentOnFailure by rememberUpdatedState(onProtectionFailure)
     // The failure filter must read the CURRENT set, not the one captured when the collector started:

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ProtectionRegistry.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ProtectionRegistry.kt
@@ -221,7 +221,14 @@ internal class ProtectionRegistry(
             } else {
                 mutate { snapshot ->
                     if (snapshot.applied[window] == capabilities) return@mutate snapshot
-                    snapshot.copy(applied = snapshot.applied + (window to capabilities))
+                    snapshot.copy(
+                        applied =
+                            if (capabilities.isEmpty()) {
+                                snapshot.applied - window
+                            } else {
+                                snapshot.applied + (window to capabilities)
+                            },
+                    )
                 }
             }
         }

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ProtectionRegistry.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ProtectionRegistry.kt
@@ -151,10 +151,14 @@ internal class ProtectionRegistry(
         mutate { snapshot ->
             val pending = snapshot.requests[WindowKey.Unbound] ?: return@mutate snapshot
             pending.forEach { it.window = window }
+            // The deferred apply parked under Unbound targeted whatever host resolved; once a real
+            // window exists, force a fresh reconcile against it rather than trusting the stale
+            // applied entry (idempotent, at worst one extra platform call).
             snapshot.copy(
                 requests =
                     snapshot.requests - WindowKey.Unbound +
                         (window to snapshot.requests[window].orEmpty() + pending),
+                applied = snapshot.applied - WindowKey.Unbound,
             )
         }
         reconcile(window)
@@ -168,7 +172,12 @@ internal class ProtectionRegistry(
      * unrelated screen.
      */
     fun releaseWindow(window: WindowKey) {
-        mutate { snapshot -> snapshot.copy(requests = snapshot.requests - window) }
+        mutate { snapshot ->
+            snapshot.copy(
+                requests = snapshot.requests - window,
+                applied = snapshot.applied - window,
+            )
+        }
         platform.clearProtection(window)
         reconcileTaskSwitcher(window)
     }
@@ -188,17 +197,32 @@ internal class ProtectionRegistry(
      * Deliberately outside the compare-and-set loop: the loop body can retry under contention, and a
      * retried platform call would toggle the window's protection flag more than once. Toggling a
      * visible window tears down and recreates its surface, which the user sees as a black frame.
+     *
+     * Skipped when the effective capability set equals what the platform was last told to apply
+     * (see [RegistryState.applied]) — a second concurrent request adding nothing new, or releasing
+     * one of two identical requests, needs no main-thread round-trip. A [ProtectionOutcome.Failed]
+     * mechanism is never recorded as applied, so the next reconcile retries the install rather than
+     * trusting a mechanism that is not in force.
      */
     private fun reconcile(window: WindowKey) {
         val capabilities = current.effectiveCapabilities(window)
 
-        if (capabilities.isEmpty()) {
-            platform.clearProtection(window)
-        } else {
-            when (platform.applyProtection(window, capabilities)) {
-                ProtectionOutcome.Applied -> Unit
-                ProtectionOutcome.Deferred -> Unit
-                ProtectionOutcome.Failed -> recordFailure(capabilities)
+        if (capabilities != current.applied[window].orEmpty()) {
+            val outcome =
+                if (capabilities.isEmpty()) {
+                    platform.clearProtection(window)
+                    ProtectionOutcome.Applied
+                } else {
+                    platform.applyProtection(window, capabilities)
+                }
+
+            if (outcome == ProtectionOutcome.Failed) {
+                recordFailure(capabilities)
+            } else {
+                mutate { snapshot ->
+                    if (snapshot.applied[window] == capabilities) return@mutate snapshot
+                    snapshot.copy(applied = snapshot.applied + (window to capabilities))
+                }
             }
         }
         pruneStaleFailures()
@@ -224,7 +248,14 @@ internal class ProtectionRegistry(
         if (prevention.isEmpty()) return
 
         mutate { it.copy(failedMechanisms = it.failedMechanisms + prevention) }
-        prevention.forEach(onProtectionFailure)
+
+        prevention.forEach { capability ->
+            // The callback runs mid-reconcile on the caller's thread: letting it throw would unwind
+            // through this reconcile path and turn a reported failure into a caller-visible crash.
+            // The swallow is deliberate — [SupportLevel] and [RegistryState.failedMechanisms] stay
+            // truthful; only this best-effort notification channel is affected.
+            runCatching { onProtectionFailure(capability) }
+        }
     }
 
     /**

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ProtectionRegistry.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ProtectionRegistry.kt
@@ -212,7 +212,7 @@ internal class ProtectionRegistry(
                 if (capabilities.isEmpty()) {
                     platform.clearProtection(window)
                     ProtectionOutcome.Applied
-                } else {
+            } else if (outcome == ProtectionOutcome.Applied) {
                     platform.applyProtection(window, capabilities)
                 }
 

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ProtectionRegistry.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ProtectionRegistry.kt
@@ -19,8 +19,16 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  * unprotect a still-visible screen underneath, with nothing to report the exposure.
  *
  * **Thread-safety**: mutations are a compare-and-set over an immutable [RegistryState] snapshot, so
- * no caller observes a half-applied change and no lock is held across the platform call. Platform
- * application is marshalled to the main thread by the actuals themselves.
+ * no caller observes a half-applied change and no caller ever retries a platform call. Platform
+ * application is marshalled to the main thread by the actuals themselves. Reconciliation — the
+ * decide → platform-call → record sequence — is additionally serialized behind [reconcileLock]:
+ * without it, a release and an acquire racing on one window can interleave so that the acquire's
+ * reconcile skips on an `applied` entry the release is about to invalidate, leaving an active
+ * request unprotected with nothing left to re-trigger the reconcile.
+ *
+ * **Capability sets are copied on entry** (`acquire`, `acquireShared`): a caller mutating a set
+ * after handing it over must not be able to change what was requested — or what the applied-cache
+ * believes was requested — after the fact.
  *
  * @param platform the platform primitive to delegate to.
  * @param onProtectionFailure invoked when a mechanism fails to install or stops working, so the
@@ -31,6 +39,9 @@ internal class ProtectionRegistry(
     private val platform: PlatformProtection,
     private val onProtectionFailure: (Capability) -> Unit = {},
 ) {
+    /** Guards [reconcile] and [releaseWindow]'s platform effects against each other. */
+    private val reconcileLock = Any()
+
     private val state = AtomicReference(RegistryState())
     private val _snapshots = MutableStateFlow(RegistryState())
 
@@ -53,7 +64,9 @@ internal class ProtectionRegistry(
         window: WindowKey,
         capabilities: Set<Capability>,
     ): ProtectionRequest {
-        val request = ProtectionRequest(capabilities, window)
+        // Copied so a caller mutating the set afterwards cannot change what was requested — or
+        // what the applied-cache compares against during reconcile.
+        val request = ProtectionRequest(capabilities.toSet(), window)
         mutate { snapshot ->
             val existing = snapshot.requests[window].orEmpty()
             snapshot.copy(requests = snapshot.requests + (window to existing + request))
@@ -80,7 +93,7 @@ internal class ProtectionRegistry(
     ): ProtectionRequest {
         sharedRequest(window, capabilities)?.let { return it }
 
-        val request = ProtectionRequest(capabilities, window, isImperative = true)
+        val request = ProtectionRequest(capabilities.toSet(), window, isImperative = true)
         mutate { snapshot ->
             val existing = snapshot.requests[window].orEmpty()
             val matches = existing.any { it.isImperative && it.capabilities == capabilities }
@@ -172,14 +185,16 @@ internal class ProtectionRegistry(
      * unrelated screen.
      */
     fun releaseWindow(window: WindowKey) {
-        mutate { snapshot ->
-            snapshot.copy(
-                requests = snapshot.requests - window,
-                applied = snapshot.applied - window,
-            )
+        serialized(reconcileLock) {
+            mutate { snapshot ->
+                snapshot.copy(
+                    requests = snapshot.requests - window,
+                    applied = snapshot.applied - window,
+                )
+            }
+            platform.clearProtection(window)
+            reconcileTaskSwitcher(window)
         }
-        platform.clearProtection(window)
-        reconcileTaskSwitcher(window)
     }
 
     /** Sets the app-switcher mode and applies the consequence immediately. */
@@ -194,9 +209,13 @@ internal class ProtectionRegistry(
     /**
      * Brings the platform in line with the current snapshot for [window].
      *
-     * Deliberately outside the compare-and-set loop: the loop body can retry under contention, and a
-     * retried platform call would toggle the window's protection flag more than once. Toggling a
-     * visible window tears down and recreates its surface, which the user sees as a black frame.
+     * Serialized behind [reconcileLock]: decide, act, and record must not interleave with another
+     * thread's reconcile for any window. Without the lock, a release and an acquire racing on one
+     * window can interleave so that the acquire skips on an `applied` entry the release is about to
+     * invalidate — leaving an active request unprotected with nothing left to re-trigger (found by
+     * external review, 2026-08-22). The lock is held across the platform call deliberately: that
+     * call runs exactly once per reconcile here, so the CAS loop's no-re-execution concern does
+     * not apply.
      *
      * Skipped when the effective capability set equals what the platform was last told to apply
      * (see [RegistryState.applied]) — a second concurrent request adding nothing new, or releasing
@@ -205,35 +224,37 @@ internal class ProtectionRegistry(
      * trusting a mechanism that is not in force.
      */
     private fun reconcile(window: WindowKey) {
-        val capabilities = current.effectiveCapabilities(window)
+        serialized(reconcileLock) {
+            val capabilities = current.effectiveCapabilities(window)
 
-        if (capabilities != current.applied[window].orEmpty()) {
-            val outcome =
-                if (capabilities.isEmpty()) {
-                    platform.clearProtection(window)
-                    ProtectionOutcome.Applied
-            } else if (outcome == ProtectionOutcome.Applied) {
-                    platform.applyProtection(window, capabilities)
-                }
+            if (capabilities != current.applied[window].orEmpty()) {
+                val outcome =
+                    if (capabilities.isEmpty()) {
+                        platform.clearProtection(window)
+                        ProtectionOutcome.Applied
+                    } else {
+                        platform.applyProtection(window, capabilities)
+                    }
 
-            if (outcome == ProtectionOutcome.Failed) {
-                recordFailure(capabilities)
-            } else {
-                mutate { snapshot ->
-                    if (snapshot.applied[window] == capabilities) return@mutate snapshot
-                    snapshot.copy(
-                        applied =
-                            if (capabilities.isEmpty()) {
-                                snapshot.applied - window
-                            } else {
-                                snapshot.applied + (window to capabilities)
-                            },
-                    )
+                if (outcome == ProtectionOutcome.Failed) {
+                    recordFailure(capabilities)
+                } else {
+                    mutate { snapshot ->
+                        if (snapshot.applied[window] == capabilities) return@mutate snapshot
+                        snapshot.copy(
+                            applied =
+                                if (capabilities.isEmpty()) {
+                                    snapshot.applied - window
+                                } else {
+                                    snapshot.applied + (window to capabilities)
+                                },
+                        )
+                    }
                 }
             }
+            pruneStaleFailures()
+            reconcileTaskSwitcher(window)
         }
-        pruneStaleFailures()
-        reconcileTaskSwitcher(window)
     }
 
     /**

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/RegistryState.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/RegistryState.kt
@@ -24,6 +24,16 @@ internal data class RegistryState(
     val failedMechanisms: Set<Capability> = emptySet(),
     /** The application's app-switcher preference. */
     val taskSwitcherMode: TaskSwitcherProtection = TaskSwitcherProtection.Automatic,
+    /**
+     * The capability set the platform was last successfully told to apply per window.
+     *
+     * [ProtectionRegistry.reconcile] compares against this to skip a platform round-trip when the
+     * effective set is unchanged — every redundant call is a main-thread dispatch, and on Android an
+     * unnecessary flag toggle tears down the window's surface. Deliberately *not* updated when a
+     * mechanism reports [ProtectionOutcome.Failed], so the next reconcile retries the install
+     * instead of believing a failed mechanism is in force.
+     */
+    val applied: Map<WindowKey, Set<Capability>> = emptyMap(),
 ) {
     /** Whether any request is outstanding on [window]. */
     fun isProtected(window: WindowKey): Boolean = requests[window]?.isNotEmpty() == true

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/Serialized.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/Serialized.kt
@@ -1,0 +1,23 @@
+package io.github.composeshield.internal
+
+/**
+ * Runs [block] while holding the process-wide reconciliation lock.
+ *
+ * Expect/actual rather than `kotlin.synchronized` because Native has no per-object monitor. The
+ * [lock] parameter keeps the signature symmetric with the JVM actual; on Native, serialization is
+ * process-wide, which is irrelevant at this call site's frequency (navigation-rate events, with
+ * platform effects that are posted or quick flag sets).
+ *
+ * Why reconcile needs mutual exclusion at all: the decide → platform-call → record sequence spans
+ * three steps, and two threads reconciling the same window concurrently can otherwise interleave so
+ * that one skips a needed apply on the strength of an `applied` entry the other is about to
+ * invalidate — leaving an active request unprotected with nothing left to re-trigger the reconcile.
+ * Holding the lock across the platform call revisits the class KDoc's older "no lock across the
+ * platform call" note deliberately: that note guards the CAS retry loop against *re-executing*
+ * platform calls under contention; a serialized reconcile executes each platform call exactly once,
+ * so there is nothing to re-execute.
+ */
+internal expect inline fun <R> serialized(
+    lock: Any,
+    block: () -> R,
+): R

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ShieldCore.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ShieldCore.kt
@@ -2,6 +2,7 @@ package io.github.composeshield.internal
 
 import io.github.composeshield.Capability
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -30,19 +31,33 @@ internal class ShieldCore(
      * Scope for the library's own long-lived collections.
      *
      * A [SupervisorJob] so a failure in one platform observer cannot cancel the others — losing
-     * screenshot events should not also silence capture-state detection. Main-dispatched because
+     * screenshot events should not also silence capture-state detection — and a
+     * [CoroutineExceptionHandler] so a failing observer cannot take the host process down: these
+     * coroutines outlive the caller that triggered them, and an unhandled error there would crash
+     * the app in exactly the way FR-021 forbids for every public operation. Main-dispatched because
      * every platform observer this drives ultimately touches UI-thread-affine APIs.
      */
-    private val scope = CoroutineScope(SupervisorJob() + mainDispatcher() + CoroutineName("ComposeShield"))
+    private val scope =
+        CoroutineScope(
+            SupervisorJob() +
+                mainDispatcher() +
+                CoroutineName("ComposeShield") +
+                // Deliberately contained; see the scope's KDoc.
+                CoroutineExceptionHandler { _, _ -> },
+        )
 
-    private val _protectionFailures = MutableSharedFlow<Capability>(extraBufferCapacity = FAILURE_BUFFER)
+    private val _protectionFailures =
+        MutableSharedFlow<Capability>(replay = FAILURE_REPLAY, extraBufferCapacity = FAILURE_BUFFER)
 
     /**
      * Mechanism failures as they happen.
      *
      * Buffered and non-suspending to publish: the registry reports failures from inside a
-     * reconcile, and a security-relevant signal must never be dropped or block the caller because
-     * nothing happened to be collecting at that instant.
+     * reconcile, so emission must neither suspend nor lose the signal when no collector is attached
+     * at that instant. [extraBufferCapacity] absorbs subscriber backpressure; [replay] covers the
+     * window *before* any collector attaches — the first boundary acquires during composition,
+     * ahead of its own failure collector, so without replay that first failure would be silently
+     * discarded. A late collector always hears the most recent failure.
      */
     val protectionFailures: Flow<Capability> = _protectionFailures.asSharedFlow()
 
@@ -59,7 +74,17 @@ internal class ShieldCore(
     /** Screenshot events, straight from the platform. Empty where unsupported, never an error. */
     val screenshotEvents: Flow<Unit> = platform.observeScreenshotEvents()
 
+    init {
+        // Capture-state observation is a long-lived library concern, not a consequence of reading
+        // the public property, so it starts here rather than as a side effect of the getter — a
+        // property read must stay a pure read. start() is idempotent.
+        captureStates.start()
+    }
+
     private companion object {
+        /** The one failure emitted before any collector attached is still owed to the next collector. */
+        const val FAILURE_REPLAY = 1
+
         const val FAILURE_BUFFER = 8
     }
 }
@@ -68,23 +93,40 @@ internal class ShieldCore(
  * The main dispatcher, or an unconfined fallback where the platform has none.
  *
  * `Dispatchers.Main` is absent in a JVM host test, a background-only process, or a JVM consumer with
- * no UI toolkit, and it then throws on **first dispatch** rather than on property access — so a
- * plain `try { Dispatchers.Main }` catches nothing and the exception escapes from whichever public
- * member first starts a coroutine. No public operation may throw because a capability is
- * unavailable, so the dispatcher is probed with a real dispatch rather than inspected.
+ * no UI toolkit — and with kotlinx-coroutines-test on the classpath resolving it can even *succeed*
+ * while every dispatch fails, so availability cannot be read off a property. The dispatcher is
+ * therefore probed with a real dispatch. No public operation may throw because a capability is
+ * unavailable, and the probe itself must stay invisible: it runs under a scope that carries its own
+ * [CoroutineExceptionHandler], because cancelling a coroutine queued on a broken dispatcher makes
+ * the failure surface asynchronously from the dispatch machinery — past the caller's try/catch,
+ * and otherwise straight into whatever uncaught-exception reporting runs next.
  *
  * The fallback does not weaken protection: platform effects are marshalled to the main thread by the
  * actuals themselves, so this scope governs only where the library's own observer coroutines resume.
  */
 @Suppress("SwallowedException", "TooGenericExceptionCaught")
-private fun mainDispatcher(): CoroutineDispatcher =
-    try {
-        val candidate = Dispatchers.Main
-        CoroutineScope(candidate).launch { }.cancel()
+private fun mainDispatcher(): CoroutineDispatcher {
+    val candidate =
+        try {
+            Dispatchers.Main
+        } catch (unavailable: Throwable) {
+            return Dispatchers.Unconfined
+        }
+
+    val probe =
+        CoroutineScope(
+            SupervisorJob() +
+                candidate +
+                // The probe's failures end here, deliberately — see the KDoc above.
+                CoroutineExceptionHandler { _, _ -> },
+        )
+    return try {
+        probe.launch { }.cancel()
         candidate
     } catch (unavailable: Throwable) {
         Dispatchers.Unconfined
     }
+}
 
 /**
  * The process-wide instance.

--- a/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ShieldCore.kt
+++ b/composeshield/src/commonMain/kotlin/io/github/composeshield/internal/ShieldCore.kt
@@ -79,6 +79,21 @@ internal class ShieldCore(
         // the public property, so it starts here rather than as a side effect of the getter — a
         // property read must stay a pure read. start() is idempotent.
         captureStates.start()
+
+        // Cold-start healing. Both Android observers resolve their host through the first
+        // registered activity, so collections begun before any window exists (an imperative
+        // `protect()` from Application.onCreate, say) sit subscribed-but-silent forever: the
+        // foreground flow that drives refresh() is itself one of the dead ones. The first
+        // concrete window binding is the event that changes that — force a genuine re-read
+        // exactly then, and never again. Event-driven; no polling.
+        scope.launch {
+            var hadConcreteWindow = false
+            registry.snapshots.collect { snapshot ->
+                val hasConcreteWindow = snapshot.requests.keys.any { it != WindowKey.Unbound }
+                if (hasConcreteWindow && !hadConcreteWindow) captureStates.refresh()
+                hadConcreteWindow = hadConcreteWindow or hasConcreteWindow
+            }
+        }
     }
 
     private companion object {
@@ -103,6 +118,11 @@ internal class ShieldCore(
  *
  * The fallback does not weaken protection: platform effects are marshalled to the main thread by the
  * actuals themselves, so this scope governs only where the library's own observer coroutines resume.
+ *
+ * Known limit: a dispatcher whose dispatch fails *asynchronously*, after this probe has returned it,
+ * cannot be detected here — verifying completion would mean blocking a constructor thread. The
+ * consequence is contained rather than prevented: such observers fail into the scope's
+ * [CoroutineExceptionHandler] instead of crashing anything.
  */
 @Suppress("SwallowedException", "TooGenericExceptionCaught")
 private fun mainDispatcher(): CoroutineDispatcher {

--- a/composeshield/src/commonTest/kotlin/io/github/composeshield/internal/ProtectionFailureTest.kt
+++ b/composeshield/src/commonTest/kotlin/io/github/composeshield/internal/ProtectionFailureTest.kt
@@ -5,6 +5,7 @@ import io.github.composeshield.SupportLevel
 import io.github.composeshield.SupportLevel.Unsupported.Reason
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -68,9 +69,11 @@ class ProtectionFailureTest {
         core.registry.acquire(WindowKey("unobserved"), setOf(Capability.ScreenshotPrevention))
 
         runTest {
+            // withTimeout so a replay regression fails here, in milliseconds, rather than as a
+            // runTest completion error after its default timeout.
             assertEquals(
                 Capability.ScreenshotPrevention,
-                core.protectionFailures.first(),
+                withTimeout(REPLAY_WAIT_MS) { core.protectionFailures.first() },
                 "a security-relevant signal must survive the window before a collector attaches",
             )
         }
@@ -88,5 +91,9 @@ class ProtectionFailureTest {
             "the durable record survives a throwing callback — only the notification channel is best-effort",
         )
         subject.release(request)
+    }
+
+    private companion object {
+        const val REPLAY_WAIT_MS = 5_000L
     }
 }

--- a/composeshield/src/commonTest/kotlin/io/github/composeshield/internal/ProtectionFailureTest.kt
+++ b/composeshield/src/commonTest/kotlin/io/github/composeshield/internal/ProtectionFailureTest.kt
@@ -3,6 +3,8 @@ package io.github.composeshield.internal
 import io.github.composeshield.Capability
 import io.github.composeshield.SupportLevel
 import io.github.composeshield.SupportLevel.Unsupported.Reason
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -52,5 +54,39 @@ class ProtectionFailureTest {
             SupportLevel.Supported,
             resolver.resolve(Capability.ScreenshotPrevention, registry.current),
         )
+    }
+
+    @Test
+    fun `a failure emitted before any collector attaches is replayed to a late collector`() {
+        // The concrete race: a composed boundary acquires during composition, ahead of its own
+        // failure collector, so the first failure is emitted into an empty room. With no replay
+        // that emission was discarded and onProtectionFailure never fired for it.
+        val core =
+            ShieldCore(
+                FakePlatformProtection().apply { nextOutcome = ProtectionOutcome.Failed },
+            )
+        core.registry.acquire(WindowKey("unobserved"), setOf(Capability.ScreenshotPrevention))
+
+        runTest {
+            assertEquals(
+                Capability.ScreenshotPrevention,
+                core.protectionFailures.first(),
+                "a security-relevant signal must survive the window before a collector attaches",
+            )
+        }
+    }
+
+    @Test
+    fun `a throwing consumer callback does not crash the caller`() {
+        val failing = FakePlatformProtection().apply { nextOutcome = ProtectionOutcome.Failed }
+        val subject = ProtectionRegistry(failing, onProtectionFailure = { error("consumer bug") })
+
+        val request = subject.acquire(WindowKey("callback-crash"), setOf(Capability.ScreenshotPrevention))
+
+        assertTrue(
+            Capability.ScreenshotPrevention in subject.current.failedMechanisms,
+            "the durable record survives a throwing callback — only the notification channel is best-effort",
+        )
+        subject.release(request)
     }
 }

--- a/composeshield/src/commonTest/kotlin/io/github/composeshield/internal/ProtectionRegistryTest.kt
+++ b/composeshield/src/commonTest/kotlin/io/github/composeshield/internal/ProtectionRegistryTest.kt
@@ -173,4 +173,48 @@ class ProtectionRegistryTest {
             "a failure describes a live attempt; keeping it would poison the capability for the session",
         )
     }
+
+    @Test
+    fun `an unchanged effective capability set does not re-invoke the platform`() {
+        val capabilities = setOf(Capability.ScreenshotPrevention)
+        val first = registry.acquire(window, capabilities)
+        val second = registry.acquire(window, capabilities)
+
+        registry.release(first)
+
+        assertEquals(
+            listOf("apply:${window.id}"),
+            platform.applyLog,
+            "a second identical request adds nothing to the union — every redundant apply is a " +
+                "main-thread round-trip, and on a real window a needless toggle tears down its surface",
+        )
+        assertContains(platform.protectedWindows, window)
+
+        registry.release(second)
+
+        assertEquals(
+            listOf("apply:${window.id}", "clear:${window.id}"),
+            platform.applyLog,
+            "skipping redundant reconciles must not skip the genuine final release",
+        )
+    }
+
+    @Test
+    fun `a failed application is retried by the next reconcile rather than trusted`() {
+        val failing = FakePlatformProtection().apply { nextOutcome = ProtectionOutcome.Failed }
+        val subject = ProtectionRegistry(failing)
+
+        subject.acquire(window, setOf(Capability.ScreenshotPrevention))
+        assertEquals(1, failing.applyLog.size)
+
+        // A second request changes nothing about the effective set, but the first apply reported
+        // Failed — the mechanism is NOT in force, so this must retry the install, not skip it.
+        subject.acquire(window, setOf(Capability.ScreenshotPrevention))
+
+        assertEquals(
+            2,
+            failing.applyLog.count { it.startsWith("fail") },
+            "caching must only trust outcomes that were actually applied; a failed install has to be retried",
+        )
+    }
 }

--- a/composeshield/src/commonTest/kotlin/io/github/composeshield/internal/ThreadSafetyTest.kt
+++ b/composeshield/src/commonTest/kotlin/io/github/composeshield/internal/ThreadSafetyTest.kt
@@ -1,9 +1,11 @@
 package io.github.composeshield.internal
 
 import io.github.composeshield.Capability
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlin.test.Test
@@ -102,8 +104,39 @@ class ThreadSafetyTest {
             )
         }
 
+    @Test
+    fun `a release racing an acquire never leaves the new request unapplied`() =
+        runTest {
+            // External-review regression guard (2026-08-22): without serialized reconciliation,
+            // the release's clear could invalidate the applied-cache entry the acquire's reconcile
+            // consults, skipping the apply — a live request left unprotected with nothing left to
+            // re-trigger it.
+            var keeper = registry.acquire(window, prevention)
+
+            repeat(RACE_ROUNDS) {
+                val next = CompletableDeferred<ProtectionRequest>()
+                withContext(Dispatchers.Default) {
+                    launch { registry.release(keeper) }
+                    launch { next.complete(registry.acquire(window, prevention)) }
+                }
+                keeper = next.await()
+
+                assertContains(
+                    platform.protectedWindows,
+                    window,
+                    "acquire() returning means its reconcile ran; a live request must be in force",
+                )
+            }
+
+            registry.release(keeper)
+            assertFalse(window in platform.protectedWindows)
+        }
+
     private companion object {
         /** Enough callers to provoke compare-and-set retries without making the test slow. */
         const val CONCURRENT_CALLERS = 64
+
+        /** Rounds of release-vs-acquire contention for the serialization regression guard. */
+        const val RACE_ROUNDS = 200
     }
 }

--- a/composeshield/src/iosMain/kotlin/io/github/composeshield/internal/Serialized.ios.kt
+++ b/composeshield/src/iosMain/kotlin/io/github/composeshield/internal/Serialized.ios.kt
@@ -1,0 +1,24 @@
+package io.github.composeshield.internal
+
+import platform.Foundation.NSRecursiveLock
+
+/**
+ * The Native actual of [serialized]: a process-wide [NSRecursiveLock] — see the expect KDoc.
+ *
+ * Recursive rather than [platform.Foundation.NSLock] because consumer callbacks run inside the
+ * guarded region (`recordFailure` reports failures mid-reconcile), and a callback that re-enters
+ * the registry must not deadlock the thread holding the lock.
+ */
+private val reconcileNativeLock = NSRecursiveLock()
+
+internal actual inline fun <R> serialized(
+    lock: Any,
+    block: () -> R,
+): R {
+    reconcileNativeLock.lock()
+    try {
+        return block()
+    } finally {
+        reconcileNativeLock.unlock()
+    }
+}

--- a/composeshield/src/iosTest/kotlin/io/github/composeshield/internal/FakeSynchronized.ios.kt
+++ b/composeshield/src/iosTest/kotlin/io/github/composeshield/internal/FakeSynchronized.ios.kt
@@ -1,6 +1,27 @@
 package io.github.composeshield.internal
 
+import platform.Foundation.NSLock
+
+/**
+ * The JVM `synchronized` actual, approximated on Native with a process-wide [NSLock].
+ *
+ * Kotlin/Native has no per-object monitor, so the [lock] parameter exists only to keep the
+ * expect/actual signature identical to the JVM side. Serialization here is process-wide rather
+ * than per-lock-object; the fakes guard small bookkeeping lists, so the coarse grain is irrelevant
+ * to the tests that use them, and it matters that concurrent mutations are genuinely serialized —
+ * an earlier version of this actual was `= block()`, which left the fake's state unsynchronized on
+ * exactly the tests meant to prove thread safety.
+ */
+private val nativeFakeLock = NSLock()
+
 internal actual inline fun <R> fakeSynchronized(
     lock: Any,
     block: () -> R,
-): R = block()
+): R {
+    nativeFakeLock.lock()
+    try {
+        return block()
+    } finally {
+        nativeFakeLock.unlock()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,7 @@ ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+# No kotlin-android alias: AGP 9 provides Kotlin support directly and nothing applies it.
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 

--- a/sample/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/sample/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -116,7 +116,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/../..\"\nif [ \"$SDK_NAME\" =~ \"simulator\" ] || [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n    if [ \"$CONFIGURATION\" = \"Release\" ]; then\n        ./gradlew :composeshield:linkReleaseFrameworkIosSimulatorArm64\n    else\n        ./gradlew :composeshield:linkDebugFrameworkIosSimulatorArm64\n    fi\nelse\n    if [ \"$CONFIGURATION\" = \"Release\" ]; then\n        ./gradlew :composeshield:linkReleaseFrameworkIosArm64\n    else\n        ./gradlew :composeshield:linkDebugFrameworkIosArm64\n    fi\nfi\n";
+			shellScript = "cd \"$SRCROOT/../..\"\nif [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n    if [ \"$CONFIGURATION\" = \"Release\" ]; then\n        ./gradlew :composeshield:linkReleaseFrameworkIosSimulatorArm64\n    else\n        ./gradlew :composeshield:linkDebugFrameworkIosSimulatorArm64\n    fi\nelse\n    if [ \"$CONFIGURATION\" = \"Release\" ]; then\n        ./gradlew :composeshield:linkReleaseFrameworkIosArm64\n    else\n        ./gradlew :composeshield:linkDebugFrameworkIosArm64\n    fi\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Improve the core protection mechanism by refining how capability requests are reconciled and applied to windows. This change ensures that redundant platform calls are avoided when the effective capability set remains unchanged, preventing unnecessary main-thread round-trips. Additionally, update the internal state management and synchronization fakes to ensure thread safety across platforms, and expand test coverage for failure reporting and registry behavior.

- Update ProtectionRegistry to handle deferred window binding more robustly
- Refactor ShieldCore and RegistryState for better internal coordination
- Enhance iOS test fakes with actual NSLock for proper synchronization
- Add comprehensive tests for capability acquisition and protection failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips redundant protection applies and stabilizes `SecureContent` capability sets to prevent Android surface teardown. Previously, equal sets re-applied protection and toggled `FLAG_SECURE`; now the registry caches the last applied set per window and retries only failed installs. `captureState` observation starts at init (not on first read), and the latest protection failure is replayed to late collectors.

- Notes for review
  - `ProtectionRegistry`: adds an `applied` cache keyed by window; reconcile skips no-ops, does not mark failures as applied, and retries on next reconcile; `bindWindow` clears Unbound applied state; `releaseWindow` clears requests and applied; failure callbacks are guarded via `runCatching`.
  - `SecureContent`: stabilizes capability inputs via `remember(capabilities.toSet())` to avoid restarting effects on equal sets; failure filtering reads the current capabilities; wraps `onProtectionFailure` to avoid crashing the host.
  - `ShieldCore`: starts capture-state observation during init; uses a `SupervisorJob` with a `CoroutineExceptionHandler`; `protectionFailures` uses `SharedFlow` with `replay = 1` to deliver the most recent failure to late collectors.
  - `ComposeShield`: `captureState` getter no longer starts work; `protectionFailures` documents replay semantics.
  - Platform/test upkeep: extracts Android API floor constants; iOS `fakeSynchronized` uses `NSLock`; build/test tweaks and Xcode script cleanup.

<sup>Written for commit 40cbf448be67256f3a5af4d58fdedb97a9954f49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abdo-essam/ComposeShield/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

